### PR TITLE
Module wurfl devicedetection

### DIFF
--- a/extra/bundle/pom.xml
+++ b/extra/bundle/pom.xml
@@ -55,13 +55,11 @@
             <artifactId>pb-request-correction</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--
         <dependency>
             <groupId>org.prebid.server.hooks.modules</groupId>
             <artifactId>wurfl-devicedetection</artifactId>
             <version>${project.version}</version>
         </dependency>
-        -->
     </dependencies>
 
     <build>

--- a/extra/modules/WURFL-devicedetection/README.md
+++ b/extra/modules/WURFL-devicedetection/README.md
@@ -22,6 +22,7 @@ The WURFL module populates missing or empty fields in ortb2.device with the foll
  - **pixelratio**: Screen pixel density ratio.
  - **devicetype**: Device type (e.g., mobile, tablet, desktop).
  - **Note**: If these fields are already populated in the bid request, the module will not overwrite them.
+
 #### Publisher-Specific Enrichment:
 
 Device enrichment is selectively enabled for publishers based on their account ID. 
@@ -30,7 +31,6 @@ The module identifies publishers through the following fields:
 `site.publisher.id` (for web environments).
 `app.publisher.id` (for mobile app environments).
 `dooh.publisher.id` (for digital out-of-home environments).
-```
 
 
 ### Build prerequisites
@@ -54,14 +54,17 @@ mvn install:install-file \
 
 ### Activating the WURFL Module
 
-The WURFL module is disabled by default. Building the Prebid Server Java with the default bundle option 
-does not include the WURFL module in the server's JAR file.
+In order to use the WURFL module, you must add the WURFL Onsite Java API dependency in the WURFL-devicedetection module's `pom.xml`:
 
-To include the WURFL module in the Prebid Server Java bundle, follow these steps:
-
-1. Uncomment the WURFL Java API dependency in `extra/modules/WURFL-devicedetection/pom.xml`.
-2. Uncomment the WURFL module dependency in `extra/bundle/pom.xml`.
-3. Uncomment the WURFL module name in the module list in `extra/modules/pom.xml`.
+```xml
+<dependency>
+    <groupId>com.scientiamobile.wurfl</groupId>
+    <artifactId>wurfl</artifactId>
+    <version>${wurfl.version}</version>
+</dependency>
+```
+If the WURFL API dependency is not added, the module will compile a demo version that returns sample data, allowing basic testing without an WURFL Onsite Java API license.
+**Note: **Before compiling the Prebid Server Java bundle with the WURFL module, you must also remove the `com` directory under `src/main/java` to avoid classloader issues.
 
 After making these changes, you can build the Prebid Server Java bundle with the WURFL module using the following command:
 

--- a/extra/modules/WURFL-devicedetection/README.md
+++ b/extra/modules/WURFL-devicedetection/README.md
@@ -19,8 +19,9 @@ The WURFL module populates missing or empty fields in ortb2.device with the foll
  - **h**: Screen height in pixels.
  - **w**: Screen width in pixels.
  - **ppi**: Screen pixels per inch (PPI).
- - **pixelratio**: Screen pixel density ratio.
+ - **pxratio**: Screen pixel density ratio.
  - **devicetype**: Device type (e.g., mobile, tablet, desktop).
+ - **js**: Support for JavaScript, where 0 = no, 1 = yes
  - **Note**: If these fields are already populated in the bid request, the module will not overwrite them.
 
 #### Publisher-Specific Enrichment:
@@ -33,14 +34,12 @@ The module identifies publishers through the following fields:
 `dooh.publisher.id` (for digital out-of-home environments).
 
 
-### Build prerequisites
+### Building WURFL Module with a licensed WURFL Onsite Java API
 
-To build the WURFL module, you need to download the WURFL Onsite Java API (both JAR and POM files) 
-from the ScientiaMobile private repository and install it in your local Maven repository. 
-Access to the WURFL Onsite Java API repository requires a valid ScientiaMobile WURFL license. 
-For more details, visit: [ScientiaMobile WURFL Onsite API for Java](https://www.scientiamobile.com/secondary-products/wurfl-onsite-api-for-java/).
+In order to compile the WURFL module in the PBS Java server bundle, you must follow these steps:
 
-Run the following command to install the WURFL API:
+1 - Download the WURFL Onsite Java API (both JAR and POM files)
+from the ScientiaMobile private repository and install it in your local Maven repository
 
 ```bash
 mvn install:install-file \
@@ -52,9 +51,7 @@ mvn install:install-file \
     -DpomFile=<path-to-your-wurfl-api-pom-file>
 ```
 
-### Activating the WURFL Module
-
-In order to use the WURFL module, you must add the WURFL Onsite Java API dependency in the WURFL-devicedetection module's `pom.xml`:
+2 - add the WURFL Onsite Java API dependency in the WURFL-devicedetection module's `pom.xml`:
 
 ```xml
 <dependency>
@@ -64,13 +61,16 @@ In order to use the WURFL module, you must add the WURFL Onsite Java API depende
 </dependency>
 ```
 If the WURFL API dependency is not added, the module will compile a demo version that returns sample data, allowing basic testing without an WURFL Onsite Java API license.
-**Note: **Before compiling the Prebid Server Java bundle with the WURFL module, you must also remove the `com` directory under `src/main/java` to avoid classloader issues.
 
-After making these changes, you can build the Prebid Server Java bundle with the WURFL module using the following command:
+3 - Remove the `com` directory under `src/main/java` to avoid classloader issues.
+
+4 - Build the Prebid Server Java bundle with the WURFL module using the following command:
 
 ```bash
 mvn clean package --file extra/pom.xml
 ```
+**NOTE** - For further automation of WURFL API dependency usage, please check the paragraph
+"Configuring your Builds to work with ScientiaMobile's Private Maven Repository" [on this page](https://docs.scientiamobile.com/documentation/onsite/onsite-java-api).
 
 ### Configuring the WURFL Module
 

--- a/extra/modules/WURFL-devicedetection/pom.xml
+++ b/extra/modules/WURFL-devicedetection/pom.xml
@@ -17,13 +17,5 @@
         <wurfl.version>1.13.3.0</wurfl.version>
       </properties>
 
-    <dependencies>
-        <!--
-        <dependency>
-            <groupId>com.scientiamobile.wurfl</groupId>
-            <artifactId>wurfl</artifactId>
-            <version>${wurfl.version}</version>
-        </dependency>
-        -->
-    </dependencies>
+    <dependencies/>
 </project>

--- a/extra/modules/WURFL-devicedetection/pom.xml
+++ b/extra/modules/WURFL-devicedetection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.prebid.server.hooks.modules</groupId>
         <artifactId>all-modules</artifactId>
-        <version>3.19.0-SNAPSHOT</version>
+        <version>3.22.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wurfl-devicedetection</artifactId>
@@ -14,7 +14,7 @@
     <description>WURFL device detection and data enrichment module</description>
 
       <properties>
-        <wurfl.version>1.13.2.1</wurfl.version>
+        <wurfl.version>1.13.3.0</wurfl.version>
       </properties>
 
     <dependencies>

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/Device.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/Device.java
@@ -23,7 +23,7 @@ public interface Device {
 
     String getWURFLUserAgent();
 
-    public int getCapabilityAsInt(String capName) throws CapabilityNotDefinedException, NumberFormatException;
+    int getCapabilityAsInt(String capName) throws CapabilityNotDefinedException, NumberFormatException;
 
     boolean getCapabilityAsBool(String capName) throws CapabilityNotDefinedException, NumberFormatException;
 }

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/Device.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/Device.java
@@ -1,0 +1,29 @@
+package com.scientiamobile.wurfl.core;
+
+import com.scientiamobile.wurfl.core.exc.VirtualCapabilityNotDefinedException;
+import com.scientiamobile.wurfl.core.exc.CapabilityNotDefinedException;
+import com.scientiamobile.wurfl.core.matchers.MatchType;
+
+public interface Device {
+
+    String getId();
+
+    MatchType getMatchType();
+
+    String getCapability(String name) throws CapabilityNotDefinedException;
+
+    String getVirtualCapability(String name)
+            throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException;
+
+    int getVirtualCapabilityAsInt(String s) throws VirtualCapabilityNotDefinedException,
+            CapabilityNotDefinedException, NumberFormatException;
+
+    boolean getVirtualCapabilityAsBool(String vcapName) throws VirtualCapabilityNotDefinedException,
+            CapabilityNotDefinedException, NumberFormatException;
+
+    String getWURFLUserAgent();
+
+    public int getCapabilityAsInt(String capName) throws CapabilityNotDefinedException, NumberFormatException;
+
+    boolean getCapabilityAsBool(String capName) throws CapabilityNotDefinedException, NumberFormatException;
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/GeneralWURFLEngine.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/GeneralWURFLEngine.java
@@ -1,0 +1,146 @@
+package com.scientiamobile.wurfl.core;
+
+import com.scientiamobile.wurfl.core.cache.CacheProvider;
+import com.scientiamobile.wurfl.core.exc.CapabilityNotDefinedException;
+import com.scientiamobile.wurfl.core.exc.VirtualCapabilityNotDefinedException;
+import com.scientiamobile.wurfl.core.matchers.MatchType;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class GeneralWURFLEngine implements WURFLEngine {
+
+    public GeneralWURFLEngine(String wurflPath){}
+
+    public static void wurflDownload(String wurflUrl, String dest) {
+    }
+
+    static final Map<String, String> capabilities = Map.ofEntries(
+            Map.entry("brand_name", "Google"),
+            Map.entry("model_name", "Pixel 9 Pro XL"),
+            Map.entry("device_os", "Android"),
+            Map.entry("device_os_version", "15.0"),
+            Map.entry("pointing_method", "touchscreen"),
+            Map.entry("is_wireless_device", "true"),
+            Map.entry("is_smarttv", "false"),
+            Map.entry("density_class", "2.55"),
+            Map.entry("resolution_width", "1344"),
+            Map.entry("resolution_height", "2992"),
+            Map.entry("ux_full_desktop", "false"),
+            Map.entry("marketing_name", ""),
+            Map.entry("mobile_browser", "Chrome Mobile"),
+            Map.entry("mobile_browser_version", ""),
+            Map.entry("preferred_markup", "html_web_4_0"),
+            Map.entry("is_connected_tv", "false"),
+            Map.entry("physical_screen_height", "158"),
+            Map.entry("ajax_support_javascript", "true"),
+            Map.entry("can_assign_phone_number", "true"),
+            Map.entry("is_ott", "false"),
+            Map.entry("is_tablet", "false"),
+            Map.entry("physical_form_factor", "phone_phablet"),
+            Map.entry("xhtml_support_level", "4")
+    );
+    static final Map<String, String> virtualCapabilities = Map.of(
+            "advertised_device_os", "Android",
+            "advertised_device_os_version", "15",
+            "pixel_density", "481",
+            "is_phone", "true",
+            "is_mobile", "true",
+            "is_full_desktop", "false",
+            "form_factor", "Smartphone",
+            "is_android", "true",
+            "is_ios", "false",
+            "complete_device_name", "Google Pixel 9 Pro XL"
+    );
+
+    final static Set<String> capabilitiesKeys = new HashSet<>(capabilities.keySet());
+    final static Set<String> virtualCapabilitiesKeys = new HashSet<>(virtualCapabilities.keySet());
+
+    @Override
+    public Set<String> getAllCapabilities() {
+        return capabilitiesKeys;
+    }
+
+    @Override
+    public Set<String> getAllVirtualCapabilities() {
+        return virtualCapabilitiesKeys;
+    }
+
+    @Override
+    public void load() {
+    }
+
+    @Override
+    public void setCacheProvider(CacheProvider cacheProvider) {
+    }
+
+    @Override
+    public Device getDeviceById(String deviceId) {
+        return mockDevice();
+    }
+
+    @Override
+    public Device getDeviceForRequest(Map<String, String> headers) {
+        return mockDevice();
+    }
+
+    private Device mockDevice() {
+        return new Device() {
+            @Override
+            public String getId() {
+                return "google_pixel_9_pro_xl_ver1_suban150";
+            }
+
+            @Override
+            public MatchType getMatchType() {
+                return MatchType.conclusive;
+            }
+
+            @Override
+            public String getCapability(String name) throws CapabilityNotDefinedException {
+                if(capabilities.containsKey(name)) {
+                    return capabilities.get(name);
+                } else {
+                    throw new CapabilityNotDefinedException(
+                            "Capability: " + name + " is not defined in WURFL");
+                }
+            }
+
+            @Override
+            public String getVirtualCapability(String name) throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException {
+                if(virtualCapabilities.containsKey(name)) {
+                    return virtualCapabilities.get(name);
+                } else {
+                    throw new VirtualCapabilityNotDefinedException(
+                            "Virtual Capability: " + name + " is not defined in WURFL");
+                }
+            }
+
+            @Override
+            public int getVirtualCapabilityAsInt(String s) throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException, NumberFormatException {
+                return 0;
+            }
+
+            @Override
+            public boolean getVirtualCapabilityAsBool(String vcapName) throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException, NumberFormatException {
+                return Boolean.parseBoolean( getVirtualCapability(vcapName));
+            }
+
+            @Override
+            public String getWURFLUserAgent() {
+                return "";
+            }
+
+            @Override
+            public int getCapabilityAsInt(String capName) throws CapabilityNotDefinedException, NumberFormatException {
+                return 0;
+            }
+
+            @Override
+            public boolean getCapabilityAsBool(String capName) throws CapabilityNotDefinedException, NumberFormatException {
+                return Boolean.parseBoolean( getCapability(capName));
+            }
+        };
+    }
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/GeneralWURFLEngine.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/GeneralWURFLEngine.java
@@ -11,12 +11,12 @@ import java.util.Set;
 
 public class GeneralWURFLEngine implements WURFLEngine {
 
-    public GeneralWURFLEngine(String wurflPath){}
+    public GeneralWURFLEngine(String wurflPath) { }
 
     public static void wurflDownload(String wurflUrl, String dest) {
     }
 
-    static final Map<String, String> capabilities = Map.ofEntries(
+    static final Map<String, String> CAPABILITIES = Map.ofEntries(
             Map.entry("brand_name", "Google"),
             Map.entry("model_name", "Pixel 9 Pro XL"),
             Map.entry("device_os", "Android"),
@@ -41,7 +41,7 @@ public class GeneralWURFLEngine implements WURFLEngine {
             Map.entry("physical_form_factor", "phone_phablet"),
             Map.entry("xhtml_support_level", "4")
     );
-    static final Map<String, String> virtualCapabilities = Map.of(
+    static final Map<String, String> VIRTUAL_CAPABILITIES = Map.of(
             "advertised_device_os", "Android",
             "advertised_device_os_version", "15",
             "pixel_density", "481",
@@ -54,17 +54,17 @@ public class GeneralWURFLEngine implements WURFLEngine {
             "complete_device_name", "Google Pixel 9 Pro XL"
     );
 
-    final static Set<String> capabilitiesKeys = new HashSet<>(capabilities.keySet());
-    final static Set<String> virtualCapabilitiesKeys = new HashSet<>(virtualCapabilities.keySet());
+    static final Set<String> CAPABILITIES_KEYS = new HashSet<>(CAPABILITIES.keySet());
+    static final Set<String> VIRTUAL_CAPABILITIES_KEYS = new HashSet<>(VIRTUAL_CAPABILITIES.keySet());
 
     @Override
     public Set<String> getAllCapabilities() {
-        return capabilitiesKeys;
+        return CAPABILITIES_KEYS;
     }
 
     @Override
     public Set<String> getAllVirtualCapabilities() {
-        return virtualCapabilitiesKeys;
+        return VIRTUAL_CAPABILITIES_KEYS;
     }
 
     @Override
@@ -99,8 +99,8 @@ public class GeneralWURFLEngine implements WURFLEngine {
 
             @Override
             public String getCapability(String name) throws CapabilityNotDefinedException {
-                if(capabilities.containsKey(name)) {
-                    return capabilities.get(name);
+                if (CAPABILITIES.containsKey(name)) {
+                    return CAPABILITIES.get(name);
                 } else {
                     throw new CapabilityNotDefinedException(
                             "Capability: " + name + " is not defined in WURFL");
@@ -108,9 +108,10 @@ public class GeneralWURFLEngine implements WURFLEngine {
             }
 
             @Override
-            public String getVirtualCapability(String name) throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException {
-                if(virtualCapabilities.containsKey(name)) {
-                    return virtualCapabilities.get(name);
+            public String getVirtualCapability(String name) throws VirtualCapabilityNotDefinedException,
+                    CapabilityNotDefinedException {
+                if (VIRTUAL_CAPABILITIES.containsKey(name)) {
+                    return VIRTUAL_CAPABILITIES.get(name);
                 } else {
                     throw new VirtualCapabilityNotDefinedException(
                             "Virtual Capability: " + name + " is not defined in WURFL");
@@ -118,13 +119,15 @@ public class GeneralWURFLEngine implements WURFLEngine {
             }
 
             @Override
-            public int getVirtualCapabilityAsInt(String s) throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException, NumberFormatException {
+            public int getVirtualCapabilityAsInt(String s) throws VirtualCapabilityNotDefinedException,
+                    CapabilityNotDefinedException, NumberFormatException {
                 return 0;
             }
 
             @Override
-            public boolean getVirtualCapabilityAsBool(String vcapName) throws VirtualCapabilityNotDefinedException, CapabilityNotDefinedException, NumberFormatException {
-                return Boolean.parseBoolean( getVirtualCapability(vcapName));
+            public boolean getVirtualCapabilityAsBool(String vcapName) throws VirtualCapabilityNotDefinedException,
+                    CapabilityNotDefinedException, NumberFormatException {
+                return Boolean.parseBoolean(getVirtualCapability(vcapName));
             }
 
             @Override
@@ -138,8 +141,9 @@ public class GeneralWURFLEngine implements WURFLEngine {
             }
 
             @Override
-            public boolean getCapabilityAsBool(String capName) throws CapabilityNotDefinedException, NumberFormatException {
-                return Boolean.parseBoolean( getCapability(capName));
+            public boolean getCapabilityAsBool(String capName) throws CapabilityNotDefinedException,
+                    NumberFormatException {
+                return Boolean.parseBoolean(getCapability(capName));
             }
         };
     }

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/WURFLEngine.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/WURFLEngine.java
@@ -6,10 +6,16 @@ import java.util.Map;
 import java.util.Set;
 
 public interface WURFLEngine {
+
     Set<String> getAllCapabilities();
+
     Set<String> getAllVirtualCapabilities();
+
     void load();
+
     void setCacheProvider(CacheProvider cacheProvider);
+
     Device getDeviceById(String deviceId);
-    Device getDeviceForRequest(Map<String,String> headers);
+
+    Device getDeviceForRequest(Map<String, String> headers);
 }

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/WURFLEngine.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/WURFLEngine.java
@@ -1,0 +1,15 @@
+package com.scientiamobile.wurfl.core;
+
+import com.scientiamobile.wurfl.core.cache.CacheProvider;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface WURFLEngine {
+    Set<String> getAllCapabilities();
+    Set<String> getAllVirtualCapabilities();
+    void load();
+    void setCacheProvider(CacheProvider cacheProvider);
+    Device getDeviceById(String deviceId);
+    Device getDeviceForRequest(Map<String,String> headers);
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/cache/CacheProvider.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/cache/CacheProvider.java
@@ -1,0 +1,4 @@
+package com.scientiamobile.wurfl.core.cache;
+
+public interface CacheProvider {
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/cache/LRUMapCacheProvider.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/cache/LRUMapCacheProvider.java
@@ -1,0 +1,8 @@
+package com.scientiamobile.wurfl.core.cache;
+
+public class LRUMapCacheProvider implements CacheProvider {
+
+    public LRUMapCacheProvider(int maxSize) {
+
+    }
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/cache/NullCacheProvider.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/cache/NullCacheProvider.java
@@ -1,0 +1,7 @@
+package com.scientiamobile.wurfl.core.cache;
+
+public class NullCacheProvider implements CacheProvider {
+
+    public NullCacheProvider() {
+    }
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/exc/CapabilityNotDefinedException.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/exc/CapabilityNotDefinedException.java
@@ -1,0 +1,12 @@
+package com.scientiamobile.wurfl.core.exc;
+
+public class CapabilityNotDefinedException extends WURFLRuntimeException {
+
+    public CapabilityNotDefinedException(String message) {
+        super(message);
+    }
+
+    public CapabilityNotDefinedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/exc/VirtualCapabilityNotDefinedException.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/exc/VirtualCapabilityNotDefinedException.java
@@ -1,0 +1,12 @@
+package com.scientiamobile.wurfl.core.exc;
+
+public class VirtualCapabilityNotDefinedException extends WURFLRuntimeException {
+
+    public VirtualCapabilityNotDefinedException(String message) {
+        super(message);
+    }
+
+    public VirtualCapabilityNotDefinedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/exc/WURFLRuntimeException.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/exc/WURFLRuntimeException.java
@@ -1,0 +1,12 @@
+package com.scientiamobile.wurfl.core.exc;
+
+public class WURFLRuntimeException extends RuntimeException {
+
+    public WURFLRuntimeException(String message) {
+        super(message);
+    }
+
+    public WURFLRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/matchers/MatchType.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/matchers/MatchType.java
@@ -1,6 +1,7 @@
 package com.scientiamobile.wurfl.core.matchers;
 
 public enum MatchType {
-        conclusive,
-        recovery
+
+    conclusive,
+    recovery
 }

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/matchers/MatchType.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/matchers/MatchType.java
@@ -1,0 +1,6 @@
+package com.scientiamobile.wurfl.core.matchers;
+
+public enum MatchType {
+        conclusive,
+        recovery
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/updater/Frequency.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/updater/Frequency.java
@@ -1,6 +1,7 @@
 package com.scientiamobile.wurfl.core.updater;
 
 public enum Frequency {
+
     DAILY,
     WEEKLY
 }

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/updater/Frequency.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/updater/Frequency.java
@@ -1,0 +1,6 @@
+package com.scientiamobile.wurfl.core.updater;
+
+public enum Frequency {
+    DAILY,
+    WEEKLY
+}

--- a/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/updater/WURFLUpdater.java
+++ b/extra/modules/WURFL-devicedetection/src/main/java/com/scientiamobile/wurfl/core/updater/WURFLUpdater.java
@@ -1,0 +1,11 @@
+package com.scientiamobile.wurfl.core.updater;
+
+import com.scientiamobile.wurfl.core.WURFLEngine;
+
+public class WURFLUpdater {
+
+    public WURFLUpdater(WURFLEngine engine, String wurflFileUrl){}
+
+    public void setFrequency(Frequency frequency){ }
+    public void performPeriodicUpdate(){}
+}

--- a/extra/modules/WURFL-devicedetection/src/main/resources/module-config/WURFL-devicedetection.yaml
+++ b/extra/modules/WURFL-devicedetection/src/main/resources/module-config/WURFL-devicedetection.yaml
@@ -39,7 +39,7 @@ hooks:
   modules:
     wurfl-devicedetection:
       wurfl-file-dir-path: </path/to/wurfl_snapshot_dir>
-      wurfl-snapshot-url: https://data.scientiamobile.com/<your_wurfl_snapshot_url>/wurfl.zip
+      wurfl-snapshot-url: https://data.scientiamobile.com/your_wurfl_snapshot_url/wurfl.zip
       cache-size: 200000
       wurfl-run-updater: true
       allowed-publisher-ids: 1

--- a/extra/modules/WURFL-devicedetection/src/test/java/org/prebid/server/hooks/modules/com/scientiamobile/wurfl/devicedetection/mock/WURFLDeviceMock.java
+++ b/extra/modules/WURFL-devicedetection/src/test/java/org/prebid/server/hooks/modules/com/scientiamobile/wurfl/devicedetection/mock/WURFLDeviceMock.java
@@ -53,7 +53,6 @@ public class WURFLDeviceMock implements com.scientiamobile.wurfl.core.Device {
         return id;
     }
 
-
     public String getWURFLUserAgent() {
         return "";
     }
@@ -86,7 +85,6 @@ public class WURFLDeviceMock implements com.scientiamobile.wurfl.core.Device {
         };
     }
 
-
     public Map<String, String> getCapabilities() {
         return Map.of();
     }
@@ -95,11 +93,9 @@ public class WURFLDeviceMock implements com.scientiamobile.wurfl.core.Device {
         return Map.of();
     }
 
-
     public boolean isActualDeviceRoot() {
         return true;
     }
-
 
     public String getDeviceRootId() {
         return "";

--- a/extra/modules/WURFL-devicedetection/src/test/java/org/prebid/server/hooks/modules/com/scientiamobile/wurfl/devicedetection/mock/WURFLDeviceMock.java
+++ b/extra/modules/WURFL-devicedetection/src/test/java/org/prebid/server/hooks/modules/com/scientiamobile/wurfl/devicedetection/mock/WURFLDeviceMock.java
@@ -49,16 +49,11 @@ public class WURFLDeviceMock implements com.scientiamobile.wurfl.core.Device {
     }
 
     @Override
-    public Map<String, String> getVirtualCapabilities() {
-        return Map.of();
-    }
-
-    @Override
     public String getId() {
         return id;
     }
 
-    @Override
+
     public String getWURFLUserAgent() {
         return "";
     }
@@ -91,17 +86,21 @@ public class WURFLDeviceMock implements com.scientiamobile.wurfl.core.Device {
         };
     }
 
-    @Override
+
     public Map<String, String> getCapabilities() {
         return Map.of();
     }
 
-    @Override
+    public Map<String, String> getVirtualCapabilities() {
+        return Map.of();
+    }
+
+
     public boolean isActualDeviceRoot() {
         return true;
     }
 
-    @Override
+
     public String getDeviceRootId() {
         return "";
     }

--- a/extra/modules/pom.xml
+++ b/extra/modules/pom.xml
@@ -24,7 +24,7 @@
         <module>pb-response-correction</module>
         <module>greenbids-real-time-data</module>
         <module>pb-request-correction</module>
-        <!-- <module>WURFL-devicedetection</module> -->
+        <module>WURFL-devicedetection</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
- Provided internal WURFL Java API mock implementation to allow module to be compiled and unit tested: mock always returns the same device in the response